### PR TITLE
CI: Fix warnings & deprecation messages in the workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Setup .NET SDK v6.0.x
-          uses: actions/setup-dotnet@v1
+          uses: actions/setup-dotnet@v4
           with:
             dotnet-version: 6.0.x
         - name: Check format
@@ -27,11 +27,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET SDK v6.0.x
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
       - name: Build
@@ -42,11 +42,11 @@ jobs:
     needs: HiddenWindow
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET SDK v6.0.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
       - name: Build and package
@@ -57,7 +57,7 @@ jobs:
           setAllVars: true
       - run: echo "Package generated artefacts/HiddenWindow.${{ env.NBGV_NuGetPackageVersion }}.nupkg"
       - name: Upload NuGet package artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nuget-packages
           path: artefacts/*.nupkg
@@ -70,7 +70,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Download NuGet package artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nuget-packages
           path: artefacts


### PR DESCRIPTION
### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 


### Which issue(s) this PR fixes:

https://github.com/G-Research/gr-oss/issues/708

------------
## Testing results

🟢 CI - https://github.com/gr-oss-devops/HiddenWindow/actions/runs/9158855070
